### PR TITLE
Fixed Grafana button href link

### DIFF
--- a/services/swarmhub/frontend/src/components/TestDetails.vue
+++ b/services/swarmhub/frontend/src/components/TestDetails.vue
@@ -44,7 +44,7 @@
 
             <div class="block">
                 <a v-if="test.SnapshotURL != ''" v-bind:href="test.SnapshotURL" target="_blank" class="button is-link">Grafana Snapshot</a>
-                <a v-else-if="grafanaConfig.Enabled == true" href="{{ grafanaconfig.BaseURL }}/d/{{ grafanaconfig.DashboardUID}}" target="_blank" class="button is-link">Grafana</a>
+                <a v-else-if="grafanaConfig.Enabled == true" v-bind:href="grafanaConfig.BaseURL + '/d/' + grafanaConfig.DashboardUID" target="_blank" class="button is-link">Grafana</a>
             </div>
 
             <div class="level">


### PR DESCRIPTION
Fix the Grafana Button to output correct link. Fix type `grafanaconfig` to `grafanaConfig`