### PR TITLE
Fixed deprecated extensions/v1beta1 apiVersion

### DIFF
--- a/deployments/k8s-files/deployer.yaml
+++ b/deployments/k8s-files/deployer.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   generation: 1

--- a/deployments/k8s-files/swarmhub.yaml
+++ b/deployments/k8s-files/swarmhub.yaml
@@ -11,7 +11,7 @@ spec:
   selector:
     app: swarmhub
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   labels:


### PR DESCRIPTION
Based on [Kubernetes 1.16 change log](https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/), `extensions/v1beta1` is deprecated and thus removed.

Migrate the `apiVersion` to use `apps/v1` instead