### PR TITLE
Added AWS S3 Region env in swarmhub k8s files

### DIFF
--- a/deployments/k8s-files/swarmhub.yaml
+++ b/deployments/k8s-files/swarmhub.yaml
@@ -51,6 +51,11 @@ spec:
             secretKeyRef:
               key: aws_s3_access_key
               name: cloud-credentials
+        - name: AWS_S3_REGION
+          valueFrom:
+            secretKeyRef:
+              key: aws_s3_region
+              name: cloud-credentials
         - name: AWS_SECRET_ACCESS_KEY
           valueFrom:
             secretKeyRef:


### PR DESCRIPTION
In [`settings.yaml`](https://github.com/att-cloudnative-labs/swarmhub/blob/master/services/swarmhub/src/swarmhub/settings.yaml), it mentioned that `AWS_S3_REGION: set in k8s deployment`.

However, in `swarmhub.yaml`, `AWS_S3_REGION` env is missing. Thus, Added `AWS_S3_REGION` in the k8s file.